### PR TITLE
Fix barebox.bbclass for multiple config fragments

### DIFF
--- a/classes/barebox.bbclass
+++ b/classes/barebox.bbclass
@@ -85,7 +85,7 @@ def find_dtss(d):
     return result
 
 apply_cfgs() {
-    fragments=${@" ".join(find_cfgs(d))}
+    fragments="${@" ".join(find_cfgs(d))}"
     if [ -n "${fragments}" ]
     then
         bbnote "Applying configuration fragments."


### PR DESCRIPTION
Due to missing quotation marks the 'apply_cfgs()' functions misbehaves for more than one configuration fragment.